### PR TITLE
Fix typo in documentation

### DIFF
--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -1,5 +1,5 @@
 module Polars
-  # Representation of a Lazy computation graph/query againat a DataFrame.
+  # Representation of a Lazy computation graph/query against a DataFrame.
   class LazyFrame
     # @private
     attr_accessor :_ldf


### PR DESCRIPTION
Trivial typo fix I happened to notice while looking at the docs.